### PR TITLE
Install shoulda matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ group :test do
   gem 'rspec-expectations'
   gem 'rspec-mocks'
   gem 'rspec-support'
+  gem 'shoulda-context'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-context (1.2.2)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     spring (2.0.1)
       activesupport (>= 4.2)
     sprockets (3.7.1)
@@ -174,6 +177,8 @@ DEPENDENCIES
   rspec-support
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-context
+  shoulda-matchers
   spring
   sqlite3
   turbolinks

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,3 +12,12 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end
+
+require 'shoulda/matchers'
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_record
+    with.library :active_model
+  end
+end


### PR DESCRIPTION
### Description
This change installs [shoulda matchers](https://github.com/thoughtbot/shoulda-matchers) into this project. Shoulda matchers provide convenient one line tests which test common Rails functionality (like model validators, uniqueness constraints etc.)

For example, to test that a file belongs to a folder  you can:

**MODELS:**
```ruby
class Folder < ActiveRecord::Base; end

class File < ActiveRecord::Base
  belongs_to :folder
end
```

**File SPEC:**
```ruby
it { should belong_to(:folder) }
```

Or to ensure that a user has a unique username:
**MODEL:**
```ruby
class User < ActiveRecord::Base
  validates_uniqueness_of :user_name
end
```

**User SPEC:**
```ruby
it { should validate_uniqueness_of(:user_name) }
```

### What was done
See the diff but the basic summary:
- Add `shoulda-matchers` and `shoulda-context` to Gemfile.
- Ran `bundle install` to install the gem into the bundle
- Added configuration to ensure the shoulda matchers 
